### PR TITLE
fix: changed ola to hola

### DIFF
--- a/examples/express.js
+++ b/examples/express.js
@@ -19,7 +19,7 @@ exports.app
 .use(vChecker('<5.x'))
 .get(baseUrl, v({
   '<1.x': (req, res) => res.send('hello'),
-  '^1.0.0': (req, res) => res.send('ola'),
+  '^1.0.0': (req, res) => res.send('hola'),
   // Matches any other valid version
   '*': (req, res) => res.send('hi')
 }))

--- a/examples/express_header.js
+++ b/examples/express_header.js
@@ -21,7 +21,7 @@ exports.app
 .use(vChecker('<5.x'))
 .get('/greetings', v({
   '<1.x': (req, res) => res.send('hello'),
-  '^1.0.0': (req, res) => res.send('ola'),
+  '^1.0.0': (req, res) => res.send('hola'),
   // Matches any other valid version
   '*': (req, res) => res.send('hi')
 }))

--- a/examples/koa.js
+++ b/examples/koa.js
@@ -27,7 +27,7 @@ router
 .use(vChecker('<5.x'))
 .get('/', v({
   '<1.x': ctx => ctx.body = 'hello',
-  '^1.0.0': ctx => ctx.body = 'ola',
+  '^1.0.0': ctx => ctx.body = 'hola',
   // Matches any other valid version
   // If you need a fallback
   //'*': ctx => ctx.body = 'hi'

--- a/examples/koa_header.js
+++ b/examples/koa_header.js
@@ -27,7 +27,7 @@ router
 .use(headerVChecker('<5.x'))
 .get('/', v({
   '<1.x': ctx => ctx.body = 'hello',
-  '^1.0.0': ctx => ctx.body = 'ola',
+  '^1.0.0': ctx => ctx.body = 'hola',
   // Matches any other valid version
   '*': ctx => ctx.body = 'hi'
 }));

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ router
   // Key: any range accepted by semver
   // value: any function
   '<1.x': ctx => ctx.body = 'hello', // if <1.x
-  '^1.0.0': ctx => ctx.body = 'ola', // else if ^1.0.0
+  '^1.0.0': ctx => ctx.body = 'hola', // else if ^1.0.0
   // Matches any other valid version
   '*': ctx => ctx.body = 'hi'        // else
 }));
@@ -58,7 +58,7 @@ app
 **Behavior:**
 ```
 curl localhost:3000/v0.0.0/greetings // hello
-curl localhost:3000/v1.0.0/greetings // ola
+curl localhost:3000/v1.0.0/greetings // hola
 curl localhost:3000/v2.0.0/greetings // hi
 ```
 
@@ -106,7 +106,7 @@ const {v} = routeV({versionPath, versionExtractor});
 ```
 
 ### Add a custom versionNotFoundErrorHandler
-By default, an error will be thrown if the version requested was not found, if it was not handled 
+By default, an error will be thrown if the version requested was not found, if it was not handled
 via a global version checker or by using the '*' range in your routes. Override this way.
 ```javascript
 // This is for Koa, for express, a similar middleware can be passed

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -9,11 +9,11 @@ const {app: expressAppHeader} = require('../examples/express_header');
 
 describe('Route V for Koa', () => {
   describe('GET /v/Greetings', () => {
-    it('should return <ola> when requesting a version compliant with ^1.0.0', async () => {
+    it('should return <hola> when requesting a version compliant with ^1.0.0', async () => {
       const {text} = await request(koaApp.callback())
       .get(`/v1.0.0/greetings`)
       .expect(200);
-      expect(text).toBe('ola');
+      expect(text).toBe('hola');
     });
     it('should return <hello> when requesting a version compliant with  <1.x', async () => {
       const {text} = await request(koaApp.callback())
@@ -41,12 +41,12 @@ describe('Route V for Koa', () => {
 
 describe('Route V (headers) for Koa', () => {
   describe('GET /v/Greetings', () => {
-    it('should return <ola> when requesting a version compliant with ^1.0.0', async () => {
+    it('should return <hola> when requesting a version compliant with ^1.0.0', async () => {
       const {text} = await request(koaAppHeader.callback())
       .get(`/greetings`)
       .set('X-API-VERSION', '1.0.0')
       .expect(200);
-      expect(text).toBe('ola');
+      expect(text).toBe('hola');
     });
     it('should return <hello> when requesting a version compliant with  <1.x', async () => {
       const {text} = await request(koaAppHeader.callback())
@@ -79,11 +79,11 @@ describe('Route V (headers) for Koa', () => {
 
 describe('Route V for express', () => {
   describe('GET /v/Greetings', () => {
-    it('should return <ola> when requesting a version compliant with ^1.0.0', async () => {
+    it('should return <hola> when requesting a version compliant with ^1.0.0', async () => {
       const {text} = await request(expressApp)
       .get(`/v1.0.0/greetings`)
       .expect(200);
-      expect(text).toBe('ola');
+      expect(text).toBe('hola');
     });
     it('should return <hello> when requesting a version compliant with  <1.x', async () => {
       const {text} = await request(expressApp)
@@ -107,12 +107,12 @@ describe('Route V for express', () => {
 
 describe('Route V (headers) for Express', () => {
   describe('GET /v/Greetings', () => {
-    it('should return <ola> when requesting a version compliant with ^1.0.0', async () => {
+    it('should return <hola> when requesting a version compliant with ^1.0.0', async () => {
       const {text} = await request(expressAppHeader)
       .get(`/greetings`)
       .set('X-API-VERSION', '1.0.0')
       .expect(200);
-      expect(text).toBe('ola');
+      expect(text).toBe('hola');
     });
     it('should return <hello> when requesting a version compliant with  <1.x', async () => {
       const {text} = await request(expressAppHeader)


### PR DESCRIPTION
Assuming you are trying to write hello in Spanish: hola means wave not
hello, it is a common mistake due to the fact that h is silent.

If you are trying to write the Portuguese word then is olá.